### PR TITLE
ci: add shared quality workflow (design-tokens profile)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,6 +12,14 @@ concurrency:
   group: quality-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
+# Least privilege for the called quality pipeline: the Quality Report job
+# posts a sticky PR comment (issues/pull-requests write); everything else
+# only reads the checkout.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   quality:
     if: github.event_name != 'push' || github.event.created != true

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,11 +12,15 @@ concurrency:
   group: quality-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
-# Least privilege for the called quality pipeline: the Quality Report job
-# posts a sticky PR comment (issues/pull-requests write); everything else
-# only reads the checkout.
+# Permission CEILING for the called quality pipeline. GitHub statically
+# validates the called workflow's declared job permissions against this
+# grant — even for jobs that are disabled — so it must cover the maximum
+# any nested job declares: journeydoc-capture (contents+actions write),
+# update-baseline / features-extract (contents write), and the Quality
+# Report PR comment (issues / pull-requests write).
 permissions:
-  contents: read
+  contents: write
+  actions: write
   issues: write
   pull-requests: write
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,32 @@
+name: Code Quality
+
+on:
+  push:
+    branches: [main, beta, development, feature/**, bugfix/**, hotfix/**]
+  pull_request:
+    types: [opened, reopened]
+    branches: [main, beta, development]
+  workflow_dispatch:
+
+concurrency:
+  group: quality-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    if: github.event_name != 'push' || github.event.created != true
+    uses: ConductionNL/.github/.github/workflows/quality.yml@main
+    with:
+      app-name: conduction-theme
+      # Design-tokens monorepo: no composer.json, so the PHP toolchain
+      # (php-quality, PHPUnit, composer security/license, SBOM) is off.
+      enable-php: false
+      # No lint/stylelint/test scripts either — enable-frontend stays false
+      # because the Vue Quality stylelint leg runs unconditionally under it.
+      # The npm Security and License legs still run, and their `npm ci`
+      # triggers this repo's postinstall (`npm run build`), so every run
+      # implicitly verifies that all design-token themes still build.
+      enable-frontend: false
+      # No openspec/specs and no docs/features.json — the features check
+      # would fail on every PR comparing "" against "[]".
+      enable-features-extract: false


### PR DESCRIPTION
Adopt the fleet quality.yml wrapper with enable-php and
enable-frontend off — this repo has no composer.json and no
lint/stylelint/test scripts. The npm Security and License legs still
run, and their npm ci triggers postinstall (npm run build), so every
run verifies all design-token themes build. Features check is off:
there is no openspec/specs to extract from.

Reports the org-standard contexts including the required
"quality / Quality Report".
